### PR TITLE
Add filtering for watched objects based on label selectors and/or annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src
 
 RUN set -ex \
     && cd /src \
-    && CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /bin/ingress-merge ./cmd/ingress-merge
+    && CGO_ENABLED=0 GOOS=linux go build -ldflags='-s -w -extldflags "-static"' -o /bin/ingress-merge ./cmd/ingress-merge
 
 FROM scratch
 COPY --from=0 /bin/ingress-merge /ingress-merge

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -35,6 +35,22 @@ func main() {
 				return err
 			}
 
+			if controller.IngressSelector, err = cmd.Flags().GetString("ingress-selector"); err != nil {
+				return err
+			}
+
+			if controller.ConfigMapSelector, err = cmd.Flags().GetString("configmap-selector"); err != nil {
+				return err
+			}
+
+			if controller.IngressBlacklist, err = cmd.Flags().GetStringArray("ingress-blacklist"); err != nil {
+				return err
+			}
+
+			if controller.ConfigMapBlacklist, err = cmd.Flags().GetStringArray("configmap-blacklist"); err != nil {
+				return err
+			}
+
 			ctx, cancel := context.WithCancel(context.Background())
 			interrupts := make(chan os.Signal, 1)
 			go func() {
@@ -70,6 +86,30 @@ func main() {
 		"ingress-class",
 		"merge",
 		"Process ingress resources with this `kubernetes.io/ingress.class` annotation.",
+	)
+
+	rootCmd.Flags().String(
+		"ingress-selector",
+		"",
+		"Process ingress resources with labels matching this selector string.",
+	)
+
+	rootCmd.Flags().String(
+		"configmap-selector",
+		"",
+		"Process configmap resources with labels matching this selector string.",
+	)
+
+	rootCmd.Flags().StringArray(
+		"ingress-blacklist",
+		[]string{},
+		"Ignore ingress resources with matching annotations (can be specified multiple times).",
+	)
+
+	rootCmd.Flags().StringArray(
+		"configmap-blacklist",
+		[]string{},
+		"Ignore configmap resources with matching annotations (can be specified multiple times).",
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -43,11 +43,11 @@ func main() {
 				return err
 			}
 
-			if controller.IngressBlacklist, err = cmd.Flags().GetStringArray("ingress-blacklist"); err != nil {
+			if controller.IngressWatchIgnore, err = cmd.Flags().GetStringArray("ingress-watch-ignore"); err != nil {
 				return err
 			}
 
-			if controller.ConfigMapBlacklist, err = cmd.Flags().GetStringArray("configmap-blacklist"); err != nil {
+			if controller.ConfigMapWatchIgnore, err = cmd.Flags().GetStringArray("configmap-watch-ignore"); err != nil {
 				return err
 			}
 
@@ -101,13 +101,13 @@ func main() {
 	)
 
 	rootCmd.Flags().StringArray(
-		"ingress-blacklist",
+		"ingress-watch-ignore",
 		[]string{},
 		"Ignore ingress resources with matching annotations (can be specified multiple times).",
 	)
 
 	rootCmd.Flags().StringArray(
-		"configmap-blacklist",
+		"configmap-watch-ignore",
 		[]string{},
 		"Ignore configmap resources with matching annotations (can be specified multiple times).",
 	)

--- a/controller.go
+++ b/controller.go
@@ -116,6 +116,22 @@ func (c *Controller) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("could not sync cache")
 	}
 
+	if c.IngressSelector != "" {
+	glog.Infof("Watching Ingress objects matching the following label selector: %v", c.IngressSelector)
+	}
+
+	if c.ConfigMapSelector != "" {
+	glog.Infof("Watching ConfigMap objects matching the following label selector: %v", c.ConfigMapSelector)
+	}
+
+	if len(c.IngressBlacklist) > 0 {
+	glog.Infof("Ignoring Ingress objects with the following annotations: %v", c.IngressBlacklist)
+	}
+
+	if len(c.ConfigMapBlacklist) > 0 {
+	glog.Infof("Ignoring ConfigMap objects with the following annotations: %v", c.ConfigMapBlacklist)
+	}
+
 	c.wakeCh = make(chan struct{}, 1)
 
 	c.Process(childCtx)

--- a/controller.go
+++ b/controller.go
@@ -177,7 +177,7 @@ func (c *Controller) OnAdd(obj interface{}) {
 }
 
 func (c *Controller) OnUpdate(oldObj, newObj interface{}) {
-	if ! c.checkBlacklist(oldObj) && ! c.checkBlacklist(newObj)  {
+	if !(c.checkBlacklist(oldObj) && c.checkBlacklist(newObj)) {
 		glog.Infof("Watched resource updated")
 		c.wakeUp()
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.2 // indirect

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -29,6 +29,14 @@ spec:
           args:
             - --logtostderr
             - --ingress-class={{ .Values.ingressClass }}
+            {{- if .Values.configmapSelector }}
+            - --configmap-selector={{ .Values.configmapSelector }}{{ end }}
+            {{- if .Values.ingressSelector }}
+            - --ingress-selector={{ .Values.ingressSelector }}{{ end }}
+            {{- range .Values.configmapBlacklist }}
+            - --configmap-blacklist={{ . }}{{ end }}
+            {{- range .Values.ingressBlacklist }}
+            - --ingress-blacklist={{ . }}{{ end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -29,14 +29,14 @@ spec:
           args:
             - --logtostderr
             - --ingress-class={{ .Values.ingressClass }}
-            {{- if .Values.configmapSelector }}
-            - --configmap-selector={{ .Values.configmapSelector }}{{ end }}
+            {{- if .Values.configMapSelector }}
+            - --configmap-selector={{ .Values.configMapSelector }}{{ end }}
             {{- if .Values.ingressSelector }}
             - --ingress-selector={{ .Values.ingressSelector }}{{ end }}
-            {{- range .Values.configmapBlacklist }}
-            - --configmap-blacklist={{ . }}{{ end }}
-            {{- range .Values.ingressBlacklist }}
-            - --ingress-blacklist={{ . }}{{ end }}
+            {{- range .Values.configMapWatchIgnore }}
+            - --configmap-watch-ignore={{ . }}{{ end }}
+            {{- range .Values.ingressWatchIgnore }}
+            - --ingress-watch-ignore={{ . }}{{ end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,18 @@
+# Ingress-class annotation to manage
 ingressClass: merge
+
+# Label selector for ConfigMap objects to be monitored for changes
+# e.g. "merge.ingress.kubernetes.io=owned"
 configmapSelector: ""
+
+# Label selector for Ingress objects to be monitored for changes
 ingressSelector: ""
+
+# List of annotations that will cause a ConfigMap to be ignored if present
+# e.g. "control-plane.alpha.kubernetes.io/leader"
 configmapBlacklist: []
+
+# List of annotations that will cause an Ingress to be ignored if present
 ingressBlacklist: []
 
 rbac:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,8 @@
 ingressClass: merge
+configmapSelector: ""
+ingressSelector: ""
+configmapBlacklist: []
+ingressBlacklist: []
 
 rbac:
   create: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,17 +3,17 @@ ingressClass: merge
 
 # Label selector for ConfigMap objects to be monitored for changes
 # e.g. "merge.ingress.kubernetes.io=owned"
-configmapSelector: ""
+configMapSelector: ""
 
 # Label selector for Ingress objects to be monitored for changes
 ingressSelector: ""
 
 # List of annotations that will cause a ConfigMap to be ignored if present
 # e.g. "control-plane.alpha.kubernetes.io/leader"
-configmapBlacklist: []
+configMapWatchIgnore: []
 
 # List of annotations that will cause an Ingress to be ignored if present
-ingressBlacklist: []
+ingressWatchIgnore: []
 
 rbac:
   create: true


### PR DESCRIPTION
I noticed that ingress-merge was entering its processing loop every two seconds on our cluster. Some digging revealed this to be due to the ALB ingress controller using a ConfigMap for locking (which it updates every two seconds). I added CLI options to filter ConfigMaps and Ingresses based on a selector string or to ignore them based on the presence of an annotation. I also added an extremely long explicit timeout to the watches, as they will otherwise err with an "old resource version" error when the watch connection ends and it reconnects. Finally, I added some comments to the helm values file and tweaked the compile options to strip debug info (doesn't affect backtraces).

Thanks a lot for writing this, it looks perfect to bridge the gap until the ALB controller handles Ingress grouping automatically.