### PR TITLE
Use single ingress-configmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 COPY . /src
 

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -51,6 +51,9 @@ func main() {
 				return err
 			}
 
+			if controller.DefaultNamespaceCm, err = cmd.Flags().GetString("configmap-default-ns"); err != nil {
+				return err
+			}
 			ctx, cancel := context.WithCancel(context.Background())
 			interrupts := make(chan os.Signal, 1)
 			go func() {
@@ -110,6 +113,12 @@ func main() {
 		"configmap-watch-ignore",
 		[]string{},
 		"Ignore configmap resources with matching annotations (can be specified multiple times).",
+	)
+
+	rootCmd.Flags().String(
+		"configmap-default-ns",
+		"",
+		"Default namespace to read configmap",
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,18 +11,22 @@ require (
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/guregu/null v3.4.0+incompatible // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/lib/pq v1.1.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/ulule/deepcopier v0.0.0-20171107155558-ca99b135e50f
 	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b // indirect
 	golang.org/x/net v0.0.0-20180921000356-2f5d2388922f // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -29,6 +29,7 @@ spec:
           args:
             - --logtostderr
             - --ingress-class={{ .Values.ingressClass }}
+            - --configmap-default-ns={{ .Release.Namespace }}
             {{- if .Values.configMapSelector }}
             - --configmap-selector={{ .Values.configMapSelector }}{{ end }}
             {{- if .Values.ingressSelector }}

--- a/helm/templates/03_configmap.yaml
+++ b/helm/templates/03_configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ingress-merge.fullname" . }}
+  labels:
+    app: {{ include "ingress-merge.name" . }}
+    chart: {{ include "ingress-merge.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  annotations: |
+  {{.Values.annotations | indent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,3 +31,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+annotations: |
+  kubernetes.io/ingress.class: alb
+  alb.ingress.kubernetes.io/scheme: internet-facing
+  alb.ingress.kubernetes.io/target-type: ip


### PR DESCRIPTION
The pr addresses:
1. Use a single configmap as `configmap-default-ns` args, this can be deployed along with helm chart and can live in the controller namespace
2. Ovverided default config with creating a config in ingresses' namespace
3. bump to go 1.12