### PR TITLE
Respect backend in Ingress resources

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,59 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: merged-ingress
+  namespace: default
+data:
+  annotations: |
+    kubernetes.io/ingress.class: alb
+  backend: |
+    serviceName: cm
+    servicePort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: src-first
+  labels:
+    app: app
+  annotations:
+    kubernetes.io/ingress.class: merge
+    merge.ingress.kubernetes.io/config: merged-ingress
+spec:
+  rules:
+    - host: first.example.com
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: first
+              servicePort: 80
+  # backend:
+  #   serviceName: ing
+  #   servicePort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: src-second
+  labels:
+    app: app
+  annotations:
+    kubernetes.io/ingress.class: merge
+    merge.ingress.kubernetes.io/config: merged-ingress
+spec:
+  rules:
+    - host: second.example.com
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: second
+              servicePort: 80
+  # backend:
+  #   serviceName: invalid-ing
+  #   servicePort: 80


### PR DESCRIPTION
Implements #8 

1. Keep the current workflow.
2. Respect default backend configuration from Ingress resource.
3. Fail if there is default backend in the ingress-merge ConfigMap and in some Ingress resource which is configured to use the ingress-merge ConfigMap.
4. Fail if two or more Ingress resources configured to use one ingress-merge ConfigMap have default backend configuration.