### PR TITLE
up2date with networking.k8s.io/v1 and go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ COPY . /src
 
 RUN set -ex \
     && cd /src \
-    && CGO_ENABLED=0 GOOS=linux go build -ldflags='-s -w -extldflags "-static"' -o /bin/ingress-merge ./cmd/ingress-merge
+    && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags='-s -w -extldflags "-static"' -o /arm64bins/ingress-merge ./cmd/ingress-merge
 
 FROM scratch
-COPY --from=0 /bin/ingress-merge /ingress-merge
+COPY --from=0 /arm64bins/ingress-merge /ingress-merge
 ENTRYPOINT ["/ingress-merge"]
 CMD ["--logtostderr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.19
 
 COPY . /src
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ resource that will be managed by different controller.
 Install via [Helm](https://www.helm.sh/):
 
 ```sh
-helm install --namespace kube-system --name ingress-merge ./helm
+helm install --namespace kube-system ingress-merge ./helm
 ```
 
 ## Example
@@ -30,7 +30,7 @@ helm install --namespace kube-system --name ingress-merge ./helm
 Create multiple ingresses & one config map that will provide parameters for the result ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-ingress
@@ -43,12 +43,15 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: foo-svc
-          servicePort: 80
+          service:
+            name: foo-svc
+            port: 
+              number: 80
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bar-ingress
@@ -61,9 +64,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: bar-svc
-          servicePort: 80
+          service:
+            name: bar-svc
+            port: 
+              number: 80
 
 ---
 apiVersion: v1
@@ -91,16 +97,20 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: bar-svc
-          servicePort: 80
+          service:
+            name: bar-svc
+            port:
+              number: 80
 
   - host: foo.example.com
     http:
       paths:
       - path: /
         backend:
-          serviceName: foo-svc
-          servicePort: 80
+          service:
+            name: foo-svc
+            port:
+              number: 80
 ```
 
 ## Annotations

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ data:
 Merge Ingress Controller will create new ingress resource named by the config map with rules combined together:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: merged-ingress

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm install --namespace kube-system --name ingress-merge ./helm
 Create multiple ingresses & one config map that will provide parameters for the result ingress:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: foo-ingress
@@ -43,12 +43,15 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: foo-svc
-          servicePort: 80
+          service:
+            name: foo-svc
+            port: 
+              number: 80
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bar-ingress
@@ -61,9 +64,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: bar-svc
-          servicePort: 80
+          service:
+            name: bar-svc
+            port: 
+              number: 80
 
 ---
 apiVersion: v1
@@ -91,16 +97,20 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: bar-svc
-          servicePort: 80
+          service:
+            name: bar-svc
+            port:
+              number: 80
 
   - host: foo.example.com
     http:
       paths:
       - path: /
         backend:
-          serviceName: foo-svc
-          servicePort: 80
+          service:
+            name: foo-svc
+            port:
+              number: 80
 ```
 
 ## Annotations

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	"github.com/jakubkulhan/ingress-merge"
+	ingress_merge "github.com/jakubkulhan/ingress-merge"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	"github.com/jakubkulhan/ingress-merge"
+	ingress_merge "github.com/ponomarevkonst/ingress-merge"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	ingress_merge "github.com/jakubkulhan/ingress-merge"
+	ingress_merge "github.com/ponomarevkonst/ingress-merge"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ingress-merge/main.go
+++ b/cmd/ingress-merge/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 
 	"github.com/golang/glog"
-	ingress_merge "github.com/ponomarevkonst/ingress-merge"
+	ingress_merge "github.com/jakubkulhan/ingress-merge"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
-module github.com/ponomarevkonst/ingress-merge
+module github.com/jakubkulhan/ingress-merge
 
 go 1.19
 
-require github.com/ghodss/yaml v1.0.0
+require (
+	github.com/ghodss/yaml v1.0.0
+	k8s.io/apimachinery v0.25.4
+)
 
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
@@ -37,7 +40,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.25.4 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jakubkulhan/ingress-merge
+module github.com/ponomarevkonst/ingress-merge
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,37 +1,56 @@
-module github.com/jakubkulhan/ingress-merge
+module github.com/ponomarevkonst/ingress-merge
+
+go 1.19
+
+require github.com/ghodss/yaml v1.0.0
 
 require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.1.1 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
-	github.com/golang/protobuf v1.2.0 // indirect
-	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
-	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/googleapis/gnostic v0.2.0 // indirect
-	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.8.1
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.2 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
-	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b // indirect
-	golang.org/x/net v0.0.0-20180921000356-2f5d2388922f // indirect
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
-	golang.org/x/sys v0.0.0-20180920110915-d641721ec2de // indirect
-	golang.org/x/text v0.3.0 // indirect
-	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
-	k8s.io/api v0.0.0-20180913155108-f456898a08e4
-	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
-	k8s.io/client-go v8.0.0+incompatible
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apimachinery v0.25.4 // indirect
+	k8s.io/klog/v2 v2.70.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
+require (
+	github.com/golang/glog v1.0.0
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.25.4
+	k8s.io/client-go v0.25.4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,37 +1,58 @@
 module github.com/jakubkulhan/ingress-merge
 
+go 1.19
+
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.1.1 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
-	github.com/golang/protobuf v1.2.0 // indirect
-	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
-	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/googleapis/gnostic v0.2.0 // indirect
-	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	k8s.io/apimachinery v0.25.4
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.8.1
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.2 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
-	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b // indirect
-	golang.org/x/net v0.0.0-20180921000356-2f5d2388922f // indirect
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
-	golang.org/x/sys v0.0.0-20180920110915-d641721ec2de // indirect
-	golang.org/x/text v0.3.0 // indirect
-	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
-	k8s.io/api v0.0.0-20180913155108-f456898a08e4
-	k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
-	k8s.io/client-go v8.0.0+incompatible
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.70.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
+require (
+	github.com/golang/glog v1.0.0
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/cobra v1.6.1
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.25.4
+	k8s.io/client-go v0.25.4
 )

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,8 +3,8 @@ name: ingress-merge
 version: 0.1-alpha1
 description: Merge Ingress Controller combines multiple ingress resorces into a new one.
 keywords:
-- ingress
-home: https://github.com/jakubkulhan/ingress-merge
+  - ingress
+home: https://github.com/ponomarevkonst/ingress-merge
 maintainers:
-- name: Jakub Kulhan
-  email: jakub.kulhan@gmail.com
+  - name: Jakub Kulhan
+    email: jakub.kulhan@gmail.com

--- a/helm/templates/01_rbac.yaml
+++ b/helm/templates/01_rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "ingress-merge.fullname" . }}
@@ -41,7 +41,7 @@ rules:
       - patch
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "ingress-merge.fullname" . }}

--- a/helm/templates/01_rbac.yaml
+++ b/helm/templates/01_rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "ingress-merge.fullname" . }}
@@ -28,7 +28,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingresses/status
@@ -41,7 +41,7 @@ rules:
       - patch
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "ingress-merge.fullname" . }}

--- a/helm/templates/01_rbac.yaml
+++ b/helm/templates/01_rbac.yaml
@@ -28,7 +28,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
       - ingresses/status

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ingress-merge.fullname" . }}

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -26,6 +26,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{ if .Values.image.pullSecrets }} 
+          imagePullSecrets:
+          {{- range .Values.image.pullSecrets }}
+            - name: {{ . }}
+          {{- end }}
+          {{ end }}
           args:
             - --logtostderr
             - --ingress-class={{ .Values.ingressClass }}

--- a/helm/templates/02_deployment.yaml
+++ b/helm/templates/02_deployment.yaml
@@ -22,16 +22,16 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ include "ingress-merge.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{ if .Values.image.pullSecrets }} 
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{ if .Values.image.pullSecrets }} 
-          imagePullSecrets:
-          {{- range .Values.image.pullSecrets }}
-            - name: {{ . }}
-          {{- end }}
-          {{ end }}
           args:
             - --logtostderr
             - --ingress-class={{ .Values.ingressClass }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,8 +20,8 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: ponomarevkonst/public:ingress-merge
-  tag: latest
+  repository: ponomarevkonst/public
+  tag: ingress-merge
   pullPolicy: Always
 
 resources: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,7 +20,7 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: jakubkulhan/ingress-merge
+  repository: ponomarevkonst/ingress-merge
   tag: latest
   pullPolicy: Always
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,8 +20,8 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: ponomarevkonst/public
-  tag: ingress-merge
+  repository: jakubkulhan/ingress-merge
+  tag: latest 
   pullPolicy: Always
 
 resources: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,9 +20,11 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: jakubkulhan/ingress-merge
-  tag: latest 
+  repository: ponomarevkonst/ingress-merge
+  tag: arm64
   pullPolicy: Always
+  pullSecrets:
+    - name: regcred
 
 resources: {}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,7 +20,7 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: ponomarevkonst/ingress-merge
+  repository: ponomarevkonst/public:ingress-merge
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
I made some updates, now it works with modern ingress objects. But I haven't changed ingress discovery method. It still selects ingress by label, not by ingressClassName field.